### PR TITLE
Ignore abort-related auth and data loading errors.

### DIFF
--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -42,6 +42,14 @@ type SortOption = 'date' | 'popularity' | 'recently_added'
 type DateRange = 'all' | 'this_week' | 'this_month' | 'next_3_months'
 type PaginationMode = 'pagination' | 'infinite_scroll'
 
+const isAbortLikeError = (err: unknown) => {
+  if (!err || typeof err !== 'object') return false
+  const maybeError = err as { name?: string; message?: string }
+  const name = (maybeError.name || '').toLowerCase()
+  const message = (maybeError.message || '').toLowerCase()
+  return name === 'aborterror' || message.includes('aborted')
+}
+
 const Events: React.FC = () => {
   const { user, loading: authLoading } = useAuth()
   const router = useRouter()
@@ -247,7 +255,9 @@ const Events: React.FC = () => {
       
       setFeaturedGroups(sortedGroups)
     } catch (err) {
-      console.error('Error loading featured groups:', err)
+      if (!isAbortLikeError(err)) {
+        console.error('Error loading featured groups:', err)
+      }
     }
   }
 
@@ -266,7 +276,9 @@ const Events: React.FC = () => {
         .order('date', { ascending: true })
 
       if (error) {
-        console.error('Error loading events:', error)
+        if (!isAbortLikeError(error)) {
+          console.error('Error loading events:', error)
+        }
         setError(`Failed to load events: ${error.message || 'Please try again.'}`)
         return
       }
@@ -375,6 +387,9 @@ const Events: React.FC = () => {
       setEvents(eventsWithRSVP)
       filterEventsDirectly(eventsWithRSVP, activeFilter)
     } catch (error) {
+      if (isAbortLikeError(error)) {
+        return
+      }
       setError('Failed to load events. Please try again.')
     } finally {
       setLoading(false)

--- a/pages/sections.tsx
+++ b/pages/sections.tsx
@@ -42,6 +42,14 @@ interface Group {
   membership_status?: 'pending' | 'approved' | 'rejected'
 }
 
+const isAbortLikeError = (err: unknown) => {
+  if (!err || typeof err !== 'object') return false
+  const maybeError = err as { name?: string; message?: string }
+  const name = (maybeError.name || '').toLowerCase()
+  const message = (maybeError.message || '').toLowerCase()
+  return name === 'aborterror' || message.includes('aborted')
+}
+
 const Sections: React.FC = () => {
   const { user, loading: authLoading } = useAuth()
   const router = useRouter()
@@ -223,6 +231,9 @@ const Sections: React.FC = () => {
       setGroups(groupsList)
       setError(null)
     } catch (err: any) {
+      if (isAbortLikeError(err)) {
+        return
+      }
       console.error('Error loading groups:', err)
       setError(err.message || 'Failed to load sections. Please refresh the page.')
     } finally {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,14 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
+const isAbortLikeError = (err: unknown) => {
+  if (!err || typeof err !== 'object') return false
+  const maybeError = err as { name?: string; message?: string }
+  const name = (maybeError.name || '').toLowerCase()
+  const message = (maybeError.message || '').toLowerCase()
+  return name === 'aborterror' || message.includes('aborted')
+}
+
 export const useAuth = () => {
   const context = useContext(AuthContext)
   if (context === undefined) {
@@ -63,7 +71,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           setLoading(false)
         }
       } catch (error) {
-        console.error('Error in getInitialSession:', error)
+        if (!isAbortLikeError(error)) {
+          console.error('Error in getInitialSession:', error)
+        }
         if (mounted) {
           setLoading(false)
         }
@@ -105,7 +115,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                   .from('profiles')
                   .insert(profileData)
                 if (insertError) {
-                  console.error('Error creating profile from OAuth:', insertError)
+                  if (!isAbortLikeError(insertError)) {
+                    console.error('Error creating profile from OAuth:', insertError)
+                  }
                 }
               } else {
                 // Update existing profile with latest OAuth data (only if fields are missing)
@@ -115,11 +127,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                   .eq('id', session.user.id)
                 if (updateError) {
                   // Ignore errors where profile might have been updated by another process
-                  console.warn('Error updating profile from OAuth (may already be updated):', updateError)
+                  if (!isAbortLikeError(updateError)) {
+                    console.warn('Error updating profile from OAuth (may already be updated):', updateError)
+                  }
                 }
               }
             } catch (profileError) {
-              console.error('Error ensuring profile exists from OAuth:', profileError)
+              if (!isAbortLikeError(profileError)) {
+                console.error('Error ensuring profile exists from OAuth:', profileError)
+              }
             }
           }
         }


### PR DESCRIPTION
Treat canceled Supabase requests as expected in auth bootstrap and events/sections loading so users don't see false error states during navigation.

Made-with: Cursor